### PR TITLE
Fix str_of_time on 64-bit systems

### DIFF
--- a/cmd/ixpc.c
+++ b/cmd/ixpc.c
@@ -79,8 +79,9 @@ str_of_mode(uint mode) {
 static char *
 str_of_time(uint val) {
 	static char buf[32];
+	time_t t = val;
 
-	ctime_r((time_t*)&val, buf);
+	ctime_r(&t, buf);
 	buf[strlen(buf) - 1] = '\0';
 	return buf;
 }


### PR DESCRIPTION
time_t is 8 bytes on 64-bit systems. Fixed so the cast doesn't read junk from adjacent stack memory.

Closes #3