### PR TITLE
Update `make doc` to use `git ls-files`

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: install deps
+      run: sudo apt-get update && sudo apt-get install -y txt2tags cproto
     - name: make clean
       run: make clean
     - name: make

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ DIRS =	lib	\
 	man
 
 doc:
-	perl $(ROOT)/util/grepdoc $$(hg manifest | grep -E '^(lib|include)') \
+	@which cproto >/dev/null 2>&1 || { echo "Error: cproto not found."; exit 1; }
+	@which txt2tags >/dev/null 2>&1 || { echo "Error: txt2tags not found."; exit 1; }
+	perl $(ROOT)/util/grepdoc $$(git ls-files | grep -E '^(lib|include)') \
 		>$(ROOT)/man/targets.mk
 	$(MAKE) -Cman
 


### PR DESCRIPTION
Assuming that Mercurial is from the Google Code days.

Also added a check for `txt2tags` and `cproto`, as if the latter is missing function signatures are omitted.

Tested with `txt2tags` 3.9