### PR TITLE
termux build

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -12,6 +12,9 @@ PREFIX = /usr/local
   LIBDIR = $(PREFIX)/lib
   INCLUDE = $(PREFIX)/include
 
+# termux/bionic
+# PREFIX = /data/data/com.termux/files/usr/local
+
 # Includes and libs
 INCLUDES = -I. -I$(ROOT)/include -I$(INCLUDE) -I/usr/include
 LIBS = -L/usr/lib -lc

--- a/util/compile
+++ b/util/compile
@@ -8,7 +8,7 @@ bin="$(echo $0 | sed 's,/[^/]*$,,')"
 
 # Derived from Russ Cox's 9c in plan9port.
 
-xtmp=/tmp/cc.$$.$USER.out
+xtmp=${TMPDIR-/tmp}/cc.$$.$USER.out
 
 echo CC $($bin/cleanname ${BASE}$outfile)
 [ -n "$noisycc" ] && echo $CC -o $outfile $CFLAGS $@

--- a/util/link
+++ b/util/link
@@ -21,7 +21,7 @@ do
 	esac
 done
 
-xtmp=/tmp/ld.$$.$USER.out
+xtmp=${TMPDIR-/tmp}/cc.$$.$USER.out
 
 echo LD "$($bin/cleanname ${BASE}$outfile)"
 [ -n "$noisycc" ] && echo $LD -o $outfile $ofiles $LDFLAGS $args


### PR DESCRIPTION
Termux/bionic does not use /tmp

I have assumed that the user will create directory /data/data/com.termux/files/usr/local, and update config.mk to use it.